### PR TITLE
Minor changes so the source could compile and fix for #738448

### DIFF
--- a/libempathy-gtk/empathy-contact-chooser.c
+++ b/libempathy-gtk/empathy-contact-chooser.c
@@ -213,7 +213,7 @@ get_contacts_cb (GObject *source,
   GError *error = NULL;
   FolksIndividual *individual;
   TpContact *contact;
-  EmpathyContact *emp_contact;
+  EmpathyContact *emp_contact = NULL;
 
   self = tp_weak_ref_dup_object (wr);
   if (self == NULL)

--- a/libempathy-gtk/empathy-theme-adium.c
+++ b/libempathy-gtk/empathy-theme-adium.c
@@ -772,7 +772,7 @@ theme_adium_remove_focus_marks (EmpathyThemeAdium *self,
   for (i = 0; i < webkit_dom_node_list_get_length (nodes); i++)
     {
       WebKitDOMNode *node = webkit_dom_node_list_item (nodes, i);
-      WebKitDOMHTMLElement *element = WEBKIT_DOM_HTML_ELEMENT (node);
+      WebKitDOMElement *element = WEBKIT_DOM_ELEMENT (node);
       gchar *class_name;
       gchar **classes, **iter;
       GString *new_class_name;
@@ -781,7 +781,7 @@ theme_adium_remove_focus_marks (EmpathyThemeAdium *self,
       if (element == NULL)
         continue;
 
-      class_name = webkit_dom_html_element_get_class_name (element);
+      class_name = webkit_dom_element_get_class_name (element);
       classes = g_strsplit (class_name, " ", -1);
       new_class_name = g_string_sized_new (strlen (class_name));
 
@@ -798,7 +798,7 @@ theme_adium_remove_focus_marks (EmpathyThemeAdium *self,
             }
         }
 
-      webkit_dom_html_element_set_class_name (element, new_class_name->str);
+      webkit_dom_element_set_class_name (element, new_class_name->str);
 
       g_free (class_name);
       g_strfreev (classes);

--- a/src/empathy-preferences.ui
+++ b/src/empathy-preferences.ui
@@ -651,6 +651,7 @@
                             <property name="xalign">0</property>
                             <property name="label" translatable="yes">Echo cancellation helps to make your voice sound clearer to the other person, but may cause problems on some computers. If you or the other person hear strange noises or glitches during calls, try turning echo cancellation off and restarting the call.</property>
                             <property name="wrap">True</property>
+                            <property name="max_width_chars">80</property>
                             <attributes>
                               <attribute name="scale" value="0.80000000000000004"/>
                             </attributes>
@@ -778,6 +779,7 @@
                             <property name="xalign">0</property>
                             <property name="label" translatable="yes">Reduced location accuracy means that nothing more precise than your city, state and country will be published.  GPS coordinates will be accurate to 1 decimal place.</property>
                             <property name="wrap">True</property>
+                            <property name="max_width_chars">80</property>
                             <attributes>
                               <attribute name="scale" value="0.80000000000000004"/>
                             </attributes>


### PR DESCRIPTION
- empathy-contact-chooser.c was raising a warning/error due to an uninitialized variable
- empathy-theme-adium.c was invoking deprecated functions and structs from Webkit3
- gtk config from empathy-preferences.ui was making preferences dialog strangely wide

(I'm sending this request mostly because some people from my CS course were trying to compile Empathy from source and were having a hard time with it. Cheers.)
